### PR TITLE
Drop support for Ruby < 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.1.10
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
   - ruby-head
 before_install:
   - gem update --system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ bundleup is in a pre-1.0 state. This means that its APIs and behavior are subjec
 ## [Unreleased][]
 
 * Your contribution here!
+* **Drop support for Ruby < 2.3**
 
 ## [0.6.1][] (2017-11-06)
 

--- a/bundleup.gemspec
+++ b/bundleup.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.3.0"
+
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "chandler"
   spec.add_development_dependency "coveralls", "~> 0.8.19"


### PR DESCRIPTION
Rubygems has dropped support for Ruby < 2.3 and the forthcoming Bundler 2.0 will drop support for Ruby < 2.3 as well.