### PR TITLE
No longer use deprecated `bundle show` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 You might like bundleup because it:
 
-* shows you exactly what gems will be updated lets you decide whether to proceed
-* uses color to call your attention to important gem updates (based on [Semver][])
-* lets you know when a version "pin" in your Gemfile is preventing an update
-* relies on standard Bundler output and does not patch code or use Bundler internals
+- shows you exactly what gems will be updated lets you decide whether to proceed
+- uses color to call your attention to important gem updates (based on [Semver][])
+- lets you know when a version "pin" in your Gemfile is preventing an update
+- relies on standard Bundler output and does not patch code or use Bundler internals
 
 Here it is in action:
 
@@ -48,27 +48,24 @@ bundleup --group=development
 
 bundleup starts by making a backup copy of your Gemfile.lock. Next it runs `bundle list`, then `bundle update` and `bundle list` again to find what gems versions are being used before and after Bundler does its updating magic. (Since gems are actually being installed into your Ruby environment during these steps, the process may take a few moments to complete, especially if gems with native extensions need to be compiled.)
 
-Finally, bundleup runs `bundle outdated` to see the gems that were *not* updated due to Gemfile restrictions.
+Finally, bundleup runs `bundle outdated` to see the gems that were _not_ updated due to Gemfile restrictions.
 
 After displaying its findings, bundleup gives you the option of keeping the changes. If you answer "no", bundleup will restore your original Gemfile.lock from its backup, leaving your project untouched.
-
 
 ## Roadmap
 
 bundleup is a very simple script at this point, but it could be more. Some possibilities:
 
-* Automatically commit the Gemfile.lock changes with a nice commit message
-* Integrate with bundler-audit to mark upgrades that have important security fixes
-* Display relevant CHANGELOG entries for major upgrades
-* Non-interactive mode
+- Automatically commit the Gemfile.lock changes with a nice commit message
+- Integrate with bundler-audit to mark upgrades that have important security fixes
+- Display relevant CHANGELOG entries for major upgrades
+- Non-interactive mode
 
 If you have other ideas, open an issue on GitHub!
-
 
 ## Contributing
 
 Code contributions are also welcome! Read [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
 
-
 [bundler]: http://bundler.io
-[Semver]: http://semver.org
+[semver]: http://semver.org

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Here it is in action:
 
 <img src="https://raw.github.com/mattbrictson/bundleup/master/sample.png" width="599" height="553" alt="Sample output">
 
+## Requirements
+
+- Bundler 1.16 or later
+- Ruby 2.4 or later
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ bundleup --group=development
 
 ## How it works
 
-bundleup starts by making a backup copy of your Gemfile.lock. Next it runs `bundle show`, then `bundle update` and `bundle show` again to find what gems versions are being used before and after Bundler does its updating magic. (Since gems are actually being installed into your Ruby environment during these steps, the process may take a few moments to complete, especially if gems with native extensions need to be compiled.)
+bundleup starts by making a backup copy of your Gemfile.lock. Next it runs `bundle list`, then `bundle update` and `bundle list` again to find what gems versions are being used before and after Bundler does its updating magic. (Since gems are actually being installed into your Ruby environment during these steps, the process may take a few moments to complete, especially if gems with native extensions need to be compiled.)
 
 Finally, bundleup runs `bundle outdated` to see the gems that were *not* updated due to Gemfile restrictions.
 

--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,7 @@ namespace :bump do
 
     replace_in_file "bundleup.gemspec", /ruby_version = ">= (.*)"/ => lowest
     replace_in_file ".rubocop.yml", /TargetRubyVersion: (.*)/ => lowest_minor
+    replace_in_file "README.md", /Ruby (\d+\.\d+)/ => lowest_minor
 
     travis = YAML.safe_load(open(".travis.yml"))
     travis["rvm"] = RubyVersions.latest_supported_patches + ["ruby-head"]

--- a/lib/bundleup/bundle_commands.rb
+++ b/lib/bundleup/bundle_commands.rb
@@ -8,8 +8,8 @@ module Bundleup
       run(%w[bundle outdated], true)
     end
 
-    def show
-      run(%w[bundle show])
+    def list
+      run(%w[bundle list])
     end
 
     def update(args=[])

--- a/lib/bundleup/upgrade.rb
+++ b/lib/bundleup/upgrade.rb
@@ -48,7 +48,7 @@ module Bundleup
     end
 
     def find_versions(type)
-      commands.show.scan(/\* (\S+) \((\S+)(?: (\S+))?\)/) do |name, ver, sha|
+      commands.list.scan(/\* (\S+) \((\S+)(?: (\S+))?\)/) do |name, ver, sha|
         gem_status(name).public_send("#{type}_version=", sha || ver)
       end
     end


### PR DESCRIPTION
Starting with Bundler 2.1, `bundle show` (with no arguments) has been deprecated in favor of `bundle list`. The `list` command was introduced in Bundler 1.16.

This commit makes bundleup use the newer `bundle list` command. As a consequence, bundleup now requires Bundler 1.16 or newer.