### PR TITLE
Simplify rubocop config with `NewCops: enable`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,31 +3,14 @@ require:
   - rubocop-performance
 
 AllCops:
+  NewCops: enable
   TargetRubyVersion: 2.5
   Exclude:
     - "*.gemspec"
     - "vendor/**/*"
 
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
 Layout/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space
-
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
 
 Metrics/AbcSize:
   Exclude:
@@ -56,35 +39,8 @@ Style/Documentation:
 Style/DoubleNegation:
   Enabled: false
 
-Style/ExponentialNotation:
-  Enabled: true
-
 Style/FrozenStringLiteralComment:
   Enabled: false
-
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashSyntax:
-  EnforcedStyle: ruby19
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
-
-Style/RedundantFetchBlock:
-  Enabled: true
-
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-
-Style/RedundantRegexpEscape:
-  Enabled: true
-
-Style/SlicingWithRange:
-  Enabled: true
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes


### PR DESCRIPTION
Now whenever we upgrade rubocop, new cops will be enabled by default without having to make tedious changes to the config.