### PR TITLE
Adopt latest `Gemfile` and `.gemspec` standards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,9 @@
 source "https://rubygems.org"
-
-# Specify your gem's dependencies in bundleup.gemspec
 gemspec
+
+gem "minitest", "~> 5.0"
+gem "minitest-reporters", "~> 1.1"
+gem "rake", "~> 13.0"
+gem "rubocop", "0.86.0"
+gem "rubocop-minitest", "0.9.0"
+gem "rubocop-performance", "1.6.1"

--- a/bundleup.gemspec
+++ b/bundleup.gemspec
@@ -1,40 +1,32 @@
-# coding: utf-8
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "bundleup/version"
+require_relative "lib/bundleup/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "bundleup"
-  spec.version       = Bundleup::VERSION
-  spec.authors       = ["Matt Brictson"]
-  spec.email         = ["bundleup@mattbrictson.com"]
+  spec.name = "bundleup"
+  spec.version = Bundleup::VERSION
+  spec.authors = ["Matt Brictson"]
+  spec.email = ["bundleup@mattbrictson.com"]
 
-  spec.summary       = "A friendlier command-line interface for Bundler’s "\
-                       "`update` and `outdated` commands."
-  spec.description   = "Use `bundleup` whenever you want to update the "\
-                       "locked Gemfile dependencies of a Ruby project. It "\
-                       "shows exactly what gems will be updated with color "\
-                       "output that calls attention to significant semver "\
-                       "changes. Bundleup will also let you know when a "\
-                       'version "pin" in your Gemfile is preventing an '\
-                       "update. Bundleup is a standalone tool that leverages "\
-                       "standard Bundler output and does not patch code or "\
-                       "use Bundler internals."
-  spec.homepage      = "https://github.com/mattbrictson/bundleup"
-  spec.license       = "MIT"
+  spec.summary = "A friendlier command-line interface for Bundler’s `update` and `outdated` commands."
+  spec.description = \
+    "Use `bundleup` whenever you want to update the locked Gemfile dependencies of a Ruby project. It shows exactly "\
+    "what gems will be updated with color output that calls attention to significant semver changes. Bundleup will "\
+    'also let you know when a version "pin" in your Gemfile is preventing an update. Bundleup is a standalone tool '\
+    "that leverages standard Bundler output and does not patch code or use Bundler internals."
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.homepage = "https://github.com/mattbrictson/bundleup"
+  spec.license = "MIT"
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
+
+  spec.metadata = {
+    "bug_tracker_uri" => "https://github.com/mattbrictson/bundleup/issues",
+    "changelog_uri" => "https://github.com/mattbrictson/bundleup/releases",
+    "source_code_uri" => "https://github.com/mattbrictson/bundleup",
+    "homepage_uri" => spec.homepage
+  }
+
+  # Specify which files should be added to the gem when it is released.
+  spec.files = `git ls-files -z exe lib LICENSE.txt README.md`.split("\x0")
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-
-  spec.required_ruby_version = ">= 2.5.0"
-
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "minitest-reporters", "~> 1.1"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rubocop", "0.86.0"
-  spec.add_development_dependency "rubocop-minitest", "0.9.0"
-  spec.add_development_dependency "rubocop-performance", "1.6.1"
 end


### PR DESCRIPTION
- Place development dependencies in the `Gemfile`, not the `.gemspec`
- Do not modify the `$LOAD_PATH` in the `.gemspec`
- Use `Gem::Requirement.new` to specify Ruby requirement
- Do not include `bundler` as a development dependency
- Reformat to a line length of 120