### PR TITLE
Install missing gems before attempting to update

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ bundleup --group=development
 
 ## How it works
 
-bundleup starts by making a backup copy of your Gemfile.lock. Next it runs `bundle list`, then `bundle update` and `bundle list` again to find what gems versions are being used before and after Bundler does its updating magic. (Since gems are actually being installed into your Ruby environment during these steps, the process may take a few moments to complete, especially if gems with native extensions need to be compiled.)
+bundleup starts by making a backup copy of your Gemfile.lock. Next it runs `bundle check` (and `bundle install` if any gems are missing in your local environment), `bundle list`, then `bundle update` and `bundle list` again to find what gems versions are being used before and after Bundler does its updating magic. (Since gems are actually being installed into your Ruby environment during these steps, the process may take a few moments to complete, especially if gems with native extensions need to be compiled.)
 
 Finally, bundleup runs `bundle outdated` to see the gems that were _not_ updated due to Gemfile restrictions.
 

--- a/lib/bundleup/bundle_commands.rb
+++ b/lib/bundleup/bundle_commands.rb
@@ -2,18 +2,39 @@ require "open3"
 
 module Bundleup
   class BundleCommands
+    class Result
+      attr_reader :output
+
+      def initialize(output, success)
+        @output = output
+        @success = success
+      end
+
+      def success?
+        @success
+      end
+    end
+
     include Console
 
+    def check
+      run(%w[bundle check], true).success?
+    end
+
+    def install
+      run(%w[bundle install]).output
+    end
+
     def outdated
-      run(%w[bundle outdated], true)
+      run(%w[bundle outdated], true).output
     end
 
     def list
-      run(%w[bundle list])
+      run(%w[bundle list]).output
     end
 
     def update(args=[])
-      run(%w[bundle update] + args)
+      run(%w[bundle update] + args).output
     end
 
     private
@@ -22,7 +43,7 @@ module Bundleup
       cmd_line = cmd.join(" ")
       progress("Running `#{cmd_line}`") do
         out, err, status = Open3.capture3(*cmd)
-        next(out) if status.success? || fail_silently
+        next(Result.new(out, status.success?)) if status.success? || fail_silently
 
         raise ["Failed to execute: #{cmd_line}", out, err].compact.join("\n")
       end

--- a/lib/bundleup/console.rb
+++ b/lib/bundleup/console.rb
@@ -78,6 +78,7 @@ module Bundleup
     # After each wait, `yield` is called to allow a block to execute.
     def observing_thread(callable, initial_wait, periodic_wait)
       thread = Thread.new(&callable)
+      thread.report_on_exception = false
       wait_for_exit(thread, initial_wait)
       loop do
         break if wait_for_exit(thread, periodic_wait)

--- a/lib/bundleup/upgrade.rb
+++ b/lib/bundleup/upgrade.rb
@@ -29,6 +29,7 @@ module Bundleup
     attr_reader :update_args, :commands, :original_lockfile_contents
 
     def run
+      commands.check || commands.install
       find_versions(:old)
       commands.update(update_args)
       find_versions(:new)


### PR DESCRIPTION
The first thing that bundleup does to upgrade a Gemfile is to run the `bundle list` command. This command fails if there are any dependencies listed in the Gemfile that are not currently installed, causing bundleup to crash.

This is annoying and happens fairly often if you are switching to a git branch where another person (or dependabot) has recently upgraded or added a dependency.

This commit fixes this crash by always running `bundle check` first, before attempting to run `bundle list`. If the check fails, bundleup will automatically run `bundle install` to ensure all dependencies are installed before it performs an upgrade.


Fixes #74 