### PR TITLE
Remove `git ls-files` to make the gemspec more portable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,10 +12,40 @@ RuboCop::RakeTask.new
 
 task default: %i[test rubocop]
 
+# == "rake release" enhancements ==============================================
+
 Rake::Task["release"].enhance do
   puts "Don't forget to publish the release on GitHub!"
   system "open https://github.com/mattbrictson/bundleup/releases"
 end
+
+task :disable_overcommit do
+  ENV["OVERCOMMIT_DISABLE"] = "1"
+end
+
+task build: :disable_overcommit
+
+task :verify_gemspec_files do
+  git_files = `git ls-files -z`.split("\x0")
+  gemspec_files = Gem::Specification.load("bundleup.gemspec").files.sort
+  ignored_by_git = gemspec_files - git_files
+  next if ignored_by_git.empty?
+
+  raise <<~ERROR
+
+    The `spec.files` specified in bundleup.gemspec include the following files
+    that are being ignored by git. Did you forget to add them to the repo? If
+    not, you may need to delete these files or modify the gemspec to ensure
+    that they are not included in the gem by mistake:
+
+    #{ignored_by_git.join("\n").gsub(/^/, '  ')}
+
+  ERROR
+end
+
+task build: :verify_gemspec_files
+
+# == "rake bump" tasks ========================================================
 
 task bump: %w[bump:bundler bump:ruby bump:year]
 

--- a/bundleup.gemspec
+++ b/bundleup.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   }
 
   # Specify which files should be added to the gem when it is released.
-  spec.files = `git ls-files -z exe lib LICENSE.txt README.md`.split("\x0")
+  spec.files = Dir.glob(%w[LICENSE.txt README.md {exe,lib}/**/*]).reject { |f| File.directory?(f) }
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Our gemspec file might be used in an environment like a Docker container where `git` is not installed. Replace `git ls-files` external shell command with Ruby's built-in `Dir.glob`.

`git ls-files` is still useful in preventing us from packaging files in the gem inadvertently, so as a safety measure use it during the build step as an enhancement to `rake release`.

Also disable overcommit during `rake release` so that we don't get failures if `rake release` is run via `bundle exec`.