### PR TITLE
Experimental feature for automatically updating Gemfile pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,37 @@ Protip: Any extra command-line arguments will be passed along to `bundle update`
 bundleup --group=development
 ```
 
-## How it works
+### Experimental: `--update-gemfile`
+
+> 💡 This is an experimental feature that may be removed or changed in future versions.
+
+Normally bundleup only makes changes to your Gemfile.lock. It honors the version restrictions ("pins") in your Gemfile and will not update your Gemfile.lock to have versions that are not allowed. However with the `--update-gemfile` flag, bundleup can update the version pins in your Gemfile as well. Consider the following Gemfile:
+
+```ruby
+gem 'sidekiq', '~> 5.2'
+gem 'rubocop', '0.89.0'
+```
+
+Normally running `bundleup` will report that these gems are pinned and therefore cannot be updated to the latest versions. However, if you pass the `--update-gemfile` option like this:
+
+```
+$ bundleup --update-gemfile
+```
+
+Now bundleup will automatically edit your Gemfile pins as needed to bring those gems up to date. For example, bundleup would change the Gemfile to look like this:
+
+```ruby
+gem 'sidekiq', '~> 6.1'
+gem 'rubocop', '0.90.0'
+```
+
+Note that `--update-gemfile` will _not_ modify Gemfile entries that contain a comment, like this:
+
+```ruby
+gem 'sidekiq', '~> 5.2' # our monkey patch doesn't work on 6.0+
+```
+
+## How bundleup works
 
 bundleup starts by making a backup copy of your Gemfile.lock. Next it runs `bundle check` (and `bundle install` if any gems are missing in your local environment), `bundle list`, then `bundle update` and `bundle list` again to find what gems versions are being used before and after Bundler does its updating magic. (Since gems are actually being installed into your Ruby environment during these steps, the process may take a few moments to complete, especially if gems with native extensions need to be compiled.)
 

--- a/lib/bundleup.rb
+++ b/lib/bundleup.rb
@@ -9,6 +9,7 @@ require "bundleup/report"
 require "bundleup/shell"
 require "bundleup/pin_report"
 require "bundleup/update_report"
+require "bundleup/version_spec"
 
 module Bundleup
   class << self

--- a/lib/bundleup/backup.rb
+++ b/lib/bundleup/backup.rb
@@ -1,5 +1,6 @@
 module Bundleup
   class Backup
+    # TODO: test multiple paths
     def self.restore_on_error(*paths)
       backup = new(*paths)
       begin

--- a/lib/bundleup/backup.rb
+++ b/lib/bundleup/backup.rb
@@ -1,7 +1,7 @@
 module Bundleup
   class Backup
-    def self.restore_on_error(path)
-      backup = new(path)
+    def self.restore_on_error(*paths)
+      backup = new(*paths)
       begin
         yield(backup)
       rescue StandardError, Interrupt
@@ -10,17 +10,20 @@ module Bundleup
       end
     end
 
-    def initialize(path)
-      @path = path
-      @original_contents = IO.read(path)
+    def initialize(*paths)
+      @original_contents = paths.each_with_object({}) do |path, hash|
+        hash[path] = IO.read(path)
+      end
     end
 
     def restore
-      IO.write(path, original_contents)
+      original_contents.each do |path, contents|
+        IO.write(path, contents)
+      end
     end
 
     private
 
-    attr_reader :path, :original_contents
+    attr_reader :original_contents
   end
 end

--- a/lib/bundleup/backup.rb
+++ b/lib/bundleup/backup.rb
@@ -1,6 +1,5 @@
 module Bundleup
   class Backup
-    # TODO: test multiple paths
     def self.restore_on_error(*paths)
       backup = new(*paths)
       begin

--- a/lib/bundleup/cli.rb
+++ b/lib/bundleup/cli.rb
@@ -81,6 +81,13 @@ module Bundleup
         these will be passed through to bundler. See #{blue('bundle update --help')} for the
         full list of the options that bundler supports.
 
+        Finally, bundleup also supports an experimental #{yellow('--update-gemfile')} option.
+        If specified, bundleup with modify the version restrictions specified in
+        your Gemfile so that it can install the latest version of each gem. For
+        instance, if your Gemfile specifies #{yellow('gem "sidekiq", "~> 5.2"')} but an update
+        to version 6.1.2 is available, bundleup will modify the Gemfile entry to
+        be #{yellow('gem "sidekiq", "~> 6.1"')} in order to permit the update.
+
         Examples:
 
             #{gray('# Update all gems')}
@@ -91,6 +98,9 @@ module Bundleup
 
             #{gray('# Only update the rake gem')}
             #{blue('$ bundleup rake')}
+
+            #{gray('# Experimental: modify Gemfile to allow the latest gem versions')}
+            #{blue('$ bundleup --update-gemfile')}
 
       USAGE
       true

--- a/lib/bundleup/cli.rb
+++ b/lib/bundleup/cli.rb
@@ -118,7 +118,6 @@ module Bundleup
       update_report, pin_report, _, outdated_gems = perform_analysis
       updatable_gems = gemfile.gem_pins_without_comments.slice(*outdated_gems.keys)
 
-      # TODO: test
       if updatable_gems.any? && @update_gemfile
         lockfile_backup.restore
         orig_gemfile = Gemfile.new

--- a/lib/bundleup/cli.rb
+++ b/lib/bundleup/cli.rb
@@ -118,6 +118,7 @@ module Bundleup
       update_report, pin_report, _, outdated_gems = perform_analysis
       updatable_gems = gemfile.gem_pins_without_comments.slice(*outdated_gems.keys)
 
+      # TODO: test
       if updatable_gems.any? && @update_gemfile
         lockfile_backup.restore
         orig_gemfile = Gemfile.new

--- a/lib/bundleup/gemfile.rb
+++ b/lib/bundleup/gemfile.rb
@@ -1,17 +1,52 @@
 module Bundleup
   class Gemfile
+    attr_reader :path
+
     def initialize(path="Gemfile")
+      @path = path
       @contents = IO.read(path)
     end
 
     def gem_comments
-      gem_names.each_with_object({}) do |gem, hash|
-        comment = inline_comment(gem) || prefix_comment(gem)
-        hash[gem] = comment unless comment.nil?
+      gem_names.each_with_object({}) do |gem_name, hash|
+        comment = inline_comment(gem_name) || prefix_comment(gem_name)
+        hash[gem_name] = comment unless comment.nil?
+      end
+    end
+
+    def gem_pins_without_comments
+      (gem_names - gem_comments.keys).each_with_object({}) do |gem_name, hash|
+        next unless (match = gem_declaration_with_pinned_version_re(gem_name).match(contents))
+
+        version = match[1]
+        hash[gem_name] = VersionSpec.parse(version)
+      end
+    end
+
+    def relax_gem_pins!(gem_names)
+      gem_names.each do |gem_name|
+        rewrite_gem_version!(gem_name, &:relax)
+      end
+    end
+
+    def shift_gem_pins!(new_gem_versions)
+      new_gem_versions.each do |gem_name, new_version|
+        rewrite_gem_version!(gem_name) { |version_spec| version_spec.shift(new_version) }
       end
     end
 
     private
+
+    def rewrite_gem_version!(gem_name)
+      found = contents.sub!(gem_declaration_with_pinned_version_re(gem_name)) do |match|
+        version = Regexp.last_match[1]
+        match[Regexp.last_match.regexp, 1] = yield(VersionSpec.parse(version)).to_s
+        match
+      end
+      raise "Can't rewrite version for #{gem_name}; it does not have a pin" unless found
+
+      IO.write(path, contents)
+    end
 
     attr_reader :contents
 
@@ -29,6 +64,10 @@ module Bundleup
 
     def gem_declaration_re(gem_name)
       /^\s*gem\s+["']#{Regexp.escape(gem_name)}["']/
+    end
+
+    def gem_declaration_with_pinned_version_re(gem_name)
+      /#{gem_declaration_re(gem_name)},\s*["'](.*?)["']/
     end
   end
 end

--- a/lib/bundleup/gemfile.rb
+++ b/lib/bundleup/gemfile.rb
@@ -14,6 +14,7 @@ module Bundleup
       end
     end
 
+    # TODO: test
     def gem_pins_without_comments
       (gem_names - gem_comments.keys).each_with_object({}) do |gem_name, hash|
         next unless (match = gem_declaration_with_pinned_version_re(gem_name).match(contents))
@@ -23,12 +24,14 @@ module Bundleup
       end
     end
 
+    # TODO: test
     def relax_gem_pins!(gem_names)
       gem_names.each do |gem_name|
         rewrite_gem_version!(gem_name, &:relax)
       end
     end
 
+    # TODO: test
     def shift_gem_pins!(new_gem_versions)
       new_gem_versions.each do |gem_name, new_version|
         rewrite_gem_version!(gem_name) { |version_spec| version_spec.shift(new_version) }

--- a/lib/bundleup/gemfile.rb
+++ b/lib/bundleup/gemfile.rb
@@ -14,7 +14,6 @@ module Bundleup
       end
     end
 
-    # TODO: test
     def gem_pins_without_comments
       (gem_names - gem_comments.keys).each_with_object({}) do |gem_name, hash|
         next unless (match = gem_declaration_with_pinned_version_re(gem_name).match(contents))
@@ -24,14 +23,12 @@ module Bundleup
       end
     end
 
-    # TODO: test
     def relax_gem_pins!(gem_names)
       gem_names.each do |gem_name|
         rewrite_gem_version!(gem_name, &:relax)
       end
     end
 
-    # TODO: test
     def shift_gem_pins!(new_gem_versions)
       new_gem_versions.each do |gem_name, new_version|
         rewrite_gem_version!(gem_name) { |version_spec| version_spec.shift(new_version) }
@@ -70,7 +67,7 @@ module Bundleup
     end
 
     def gem_declaration_with_pinned_version_re(gem_name)
-      /#{gem_declaration_re(gem_name)},\s*["'](.*?)["']/
+      /#{gem_declaration_re(gem_name)},\s*["']([^'"]+)["']\s*$/
     end
   end
 end

--- a/lib/bundleup/report.rb
+++ b/lib/bundleup/report.rb
@@ -3,7 +3,11 @@ require "forwardable"
 module Bundleup
   class Report
     extend Forwardable
-    def_delegators :rows, :empty?
+    def_delegators :rows, :empty?, :one?
+
+    def many?
+      rows.length > 1
+    end
 
     def to_s
       [

--- a/lib/bundleup/version_spec.rb
+++ b/lib/bundleup/version_spec.rb
@@ -1,0 +1,46 @@
+module Bundleup
+  class VersionSpec
+    def self.parse(version)
+      return version if version.is_a?(VersionSpec)
+
+      version = version.strip
+      _, operator, number = version.match(/^([^\d\s]*)\s*(.+)/).to_a
+      operator = nil if operator.empty?
+
+      new(parts: number.split("."), operator: operator)
+    end
+
+    attr_reader :parts, :operator
+
+    def initialize(parts:, operator: nil)
+      @parts = parts
+      @operator = operator
+    end
+
+    def exact?
+      operator.nil?
+    end
+
+    def relax
+      return self if %w[!= > >=].include?(operator)
+
+      self.class.new(parts: parts, operator: ">=")
+    end
+
+    def shift(new_version)
+      return self if %w[!= >].include?(operator)
+
+      new_version = self.class.parse(new_version)
+      new_slice = exact? ? new_version : new_version.slice(parts.length)
+      self.class.new(parts: new_slice.parts, operator: operator)
+    end
+
+    def slice(amount)
+      self.class.new(parts: parts[0, amount], operator: operator)
+    end
+
+    def to_s
+      [operator, parts.join(".")].compact.join(" ")
+    end
+  end
+end

--- a/lib/bundleup/version_spec.rb
+++ b/lib/bundleup/version_spec.rb
@@ -44,5 +44,11 @@ module Bundleup
     def to_s
       [operator, parts.join(".")].compact.join(" ")
     end
+
+    def ==(other)
+      return false unless other.is_a?(VersionSpec)
+
+      to_s == other.to_s
+    end
   end
 end

--- a/test/bundleup/gemfile_test.rb
+++ b/test/bundleup/gemfile_test.rb
@@ -1,9 +1,9 @@
 require "test_helper"
+require "tempfile"
 
 class Bundleup::GemfileTest < Minitest::Test
   def test_gem_comments
-    gemfile_path = File.expand_path("../fixtures/Gemfile.sample", __dir__)
-    gemfile = Bundleup::Gemfile.new(gemfile_path)
+    gemfile = with_copy_of_sample_gemfile { |path| Bundleup::Gemfile.new(path) }
 
     # rubocop:disable Layout/LineLength
     assert_equal(
@@ -26,5 +26,154 @@ class Bundleup::GemfileTest < Minitest::Test
       gemfile.gem_comments
     )
     # rubocop:enable Layout/LineLength
+  end
+
+  def test_gem_pins_without_comments
+    gemfile = with_copy_of_sample_gemfile { |path| Bundleup::Gemfile.new(path) }
+    assert_equal(
+      {
+        "spring-watcher-listen" => Bundleup::VersionSpec.parse("~> 2.0.0")
+      },
+      gemfile.gem_pins_without_comments
+    )
+  end
+
+  def test_relax_gem_pins!
+    with_copy_of_sample_gemfile do |path|
+      Bundleup::Gemfile.new(path).relax_gem_pins!(%w[rails uglifier capybara])
+
+      assert_equal(<<~'GEMFILE', IO.read(path))
+        source 'https://rubygems.org'
+
+        git_source(:github) do |repo_name|
+          repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+          "https://github.com/#{repo_name}.git"
+        end
+
+
+        # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+        gem 'rails', '>= 5.1.4'
+        # Use postgresql as the database for Active Record
+        gem 'pg', '~> 0.18'
+        # Use Puma as the app server
+        gem 'puma', '~> 3.7'
+        # Use SCSS for stylesheets
+        gem 'sass-rails', '~> 5.0'
+        # Use Uglifier as compressor for JavaScript assets
+        gem 'uglifier', '>= 1.3.0'
+        # See https://github.com/rails/execjs#readme for more supported runtimes
+        # gem 'therubyracer', platforms: :ruby
+
+        # Use CoffeeScript for .coffee assets and views
+        gem 'coffee-rails', '~> 4.2'
+        # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
+        gem 'turbolinks', '~> 5'
+        # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
+        gem 'jbuilder', '~> 2.5'
+        # Use Redis adapter to run Action Cable in production
+        # gem 'redis', '~> 3.0'
+        # Use ActiveModel has_secure_password
+        # gem 'bcrypt', '~> 3.1.7'
+
+        # Use Capistrano for deployment
+        # gem 'capistrano-rails', group: :development
+
+        group :development, :test do
+          # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+          gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+          # Adds support for Capybara system testing and selenium driver
+          gem 'capybara', '>= 2.13'
+          gem 'selenium-webdriver' # This is needed for driven_by :chrome
+        end
+
+        group :development do
+          # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
+          gem 'web-console', '>= 3.3.0'
+          gem 'listen', '>= 3.0.5', '< 3.2'
+          # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+          gem 'spring'
+          gem 'spring-watcher-listen', '~> 2.0.0'
+        end
+
+        # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+        gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+      GEMFILE
+    end
+  end
+
+  def test_shift_gem_pins!
+    with_copy_of_sample_gemfile do |path|
+      Bundleup::Gemfile.new(path).shift_gem_pins!(
+        "rails" => "6.0.1.3",
+        "uglifier" => "1.4.5",
+        "capybara" => "3.9.1"
+      )
+
+      assert_equal(<<~'GEMFILE', IO.read(path))
+        source 'https://rubygems.org'
+
+        git_source(:github) do |repo_name|
+          repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+          "https://github.com/#{repo_name}.git"
+        end
+
+
+        # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+        gem 'rails', '~> 6.0.1'
+        # Use postgresql as the database for Active Record
+        gem 'pg', '~> 0.18'
+        # Use Puma as the app server
+        gem 'puma', '~> 3.7'
+        # Use SCSS for stylesheets
+        gem 'sass-rails', '~> 5.0'
+        # Use Uglifier as compressor for JavaScript assets
+        gem 'uglifier', '>= 1.3.0'
+        # See https://github.com/rails/execjs#readme for more supported runtimes
+        # gem 'therubyracer', platforms: :ruby
+
+        # Use CoffeeScript for .coffee assets and views
+        gem 'coffee-rails', '~> 4.2'
+        # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
+        gem 'turbolinks', '~> 5'
+        # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
+        gem 'jbuilder', '~> 2.5'
+        # Use Redis adapter to run Action Cable in production
+        # gem 'redis', '~> 3.0'
+        # Use ActiveModel has_secure_password
+        # gem 'bcrypt', '~> 3.1.7'
+
+        # Use Capistrano for deployment
+        # gem 'capistrano-rails', group: :development
+
+        group :development, :test do
+          # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+          gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+          # Adds support for Capybara system testing and selenium driver
+          gem 'capybara', '~> 3.9'
+          gem 'selenium-webdriver' # This is needed for driven_by :chrome
+        end
+
+        group :development do
+          # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
+          gem 'web-console', '>= 3.3.0'
+          gem 'listen', '>= 3.0.5', '< 3.2'
+          # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+          gem 'spring'
+          gem 'spring-watcher-listen', '~> 2.0.0'
+        end
+
+        # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+        gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+      GEMFILE
+    end
+  end
+
+  private
+
+  def with_copy_of_sample_gemfile
+    file = Tempfile.new
+    file << IO.read(File.expand_path("../fixtures/Gemfile.sample", __dir__))
+    file.close
+    yield file.path
   end
 end

--- a/test/bundleup/version_spec_test.rb
+++ b/test/bundleup/version_spec_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+class Bundleup::VersionSpecTest < Minitest::Test
+  def test_relax_doesnt_affect_greater_than_equal_specs
+    assert_equal(">= 1.0.1", parse(">= 1.0.1").relax.to_s)
+  end
+
+  def test_relax_doesnt_affect_not_equal_specs
+    assert_equal("!= 5.2.0", parse("!= 5.2.0").relax.to_s)
+  end
+
+  def test_relax_doesnt_affect_greater_than_specs
+    assert_equal("> 1.0.1", parse("> 1.0.1").relax.to_s)
+  end
+
+  def test_relax_changes_approximate_specs_to_greater_than_equal
+    assert_equal(">= 5", parse("~> 5").relax.to_s)
+    assert_equal(">= 5.2", parse("~> 5.2").relax.to_s)
+    assert_equal(">= 5.2.0", parse("~> 5.2.0").relax.to_s)
+  end
+
+  def test_relax_changes_exact_specs_to_greater_than_equal
+    assert_equal(">= 0.89.0", parse("0.89.0").relax.to_s)
+  end
+
+  def test_relax_changes_less_than_specs_to_greater_than_equal_zero
+    assert_equal(">= 0", parse("< 1.9.5").relax.to_s)
+  end
+
+  def test_relax_changes_less_than_equal_specs_to_greater_than_equal_zero
+    assert_equal(">= 0", parse("<= 1.9.5").relax.to_s)
+  end
+
+  def test_shift_doesnt_affect_greater_than_equal_specs
+    assert_equal(">= 1.0.1", parse(">= 1.0.1").shift("2.3.5").to_s)
+  end
+
+  def test_shift_doesnt_affect_not_equal_specs
+    assert_equal("!= 5.2.0", parse("!= 5.2.0").shift("6.1.2").to_s)
+  end
+
+  def test_shift_doesnt_affect_greater_than_specs
+    assert_equal("> 1.0.1", parse("> 1.0.1").shift("2.3.5").to_s)
+  end
+
+  def test_shift_doesnt_affect_approximate_specs_if_new_version_is_compatible
+    assert_equal("~> 5.2.0", parse("~> 5.2.0").shift("5.2.6").to_s)
+    assert_equal("~> 5.2", parse("~> 5.2").shift("5.4.9").to_s)
+  end
+
+  def test_shift_changes_exact_spec_to_new_version
+    assert_equal("0.90.0", parse("0.89.0").shift("0.90.0").to_s)
+  end
+
+  def test_shift_changes_approximate_specs_to_accomodate_new_version
+    assert_equal("~> 6", parse("~> 5").shift("6.1.2").to_s)
+    assert_equal("~> 6.1", parse("~> 5.2").shift("6.1.2").to_s)
+    assert_equal("~> 6.1.2", parse("~> 5.2.0").shift("6.1.2").to_s)
+  end
+
+  def test_shift_changes_less_than_specs_to_less_than_equal
+    assert_equal("<= 2.1.4", parse("< 1.9.5").shift("2.1.4").to_s)
+  end
+
+  def test_shift_changes_less_than_equal_specs_to_accomodate_new_veresion
+    assert_equal("<= 2.1.4", parse("<= 1.9.5").shift("2.1.4").to_s)
+  end
+
+  private
+
+  def parse(spec)
+    Bundleup::VersionSpec.parse(spec)
+  end
+end


### PR DESCRIPTION
This PR introduces a `--update-gemfile` flag. When specified, bundleup can update the version pins in your Gemfile in addition to the Gemfile.lock. Consider the following Gemfile:

```ruby
gem 'sidekiq', '~> 5.2'
gem 'rubocop', '0.89.0'
```

Normally running `bundleup` will report that these gems are pinned and therefore cannot be updated to the latest versions. However, if you pass the `--update-gemfile` option like this:

```
$ bundleup --update-gemfile
```

Now bundleup will automatically edit your Gemfile pins as needed to bring those gems up to date. For example, bundleup would change the Gemfile to look like this:

```ruby
gem 'sidekiq', '~> 6.1'
gem 'rubocop', '0.90.0'
```

Note that `--update-gemfile` will _not_ modify Gemfile entries that contain a comment, like this:

```ruby
gem 'sidekiq', '~> 5.2' # our monkey patch doesn't work on 6.0+
```
