### PR TITLE
Replace minitest-reporters with minitest-rg

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "minitest", "~> 5.0"
-gem "minitest-reporters", "~> 1.1"
+gem "minitest-rg", "~> 5.3"
 gem "mocha", "~> 2.0"
 gem "rake", "~> 13.0"
 gem "rubocop", "1.58.0"

--- a/test/support/minitest_reporters.rb
+++ b/test/support/minitest_reporters.rb
@@ -1,7 +1,0 @@
-require "minitest/reporters"
-
-if ENV["CI"]
-  Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new)
-else
-  Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new)
-end

--- a/test/support/rg.rb
+++ b/test/support/rg.rb
@@ -1,0 +1,2 @@
+# Enable color test output
+require "minitest/rg"


### PR DESCRIPTION
Remove `minitest-reporters` in favor of `minitest-rg`, which is simpler, is officially maintained by the minitest GitHub organization, and doesn't patch minitest internals in ways that can break other plugins