### PR TITLE
Drop support for Ruby 3.0 (EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
+        ruby: ["3.1", "3.2", "3.3", "head"]
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   Exclude:
     - "vendor/**/*"
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here it is in action:
 ## Requirements
 
 - Bundler 1.16 or later
-- Ruby 3.0 or later
+- Ruby 3.1 or later
 
 ## Usage
 

--- a/bundleup.gemspec
+++ b/bundleup.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.homepage = "https://github.com/mattbrictson/bundleup"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/mattbrictson/bundleup/issues",

--- a/lib/bundleup/cli.rb
+++ b/lib/bundleup/cli.rb
@@ -18,7 +18,7 @@ module Bundleup
     end
 
     def run # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      print_usage && return if (args & %w[-h --help]).any?
+      print_usage && return if args.intersect?(%w[-h --help])
 
       @updated_gems = []
       @pinned_gems = []

--- a/lib/bundleup/cli.rb
+++ b/lib/bundleup/cli.rb
@@ -149,8 +149,8 @@ module Bundleup
       new_versions = commands.list
       outdated_gems = commands.outdated
 
-      update_report = UpdateReport.new(old_versions: old_versions, new_versions: new_versions)
-      pin_report = PinReport.new(gem_versions: new_versions, outdated_gems: outdated_gems, gem_comments: gem_comments)
+      update_report = UpdateReport.new(old_versions:, new_versions:)
+      pin_report = PinReport.new(gem_versions: new_versions, outdated_gems:, gem_comments:)
 
       [update_report, pin_report, new_versions, outdated_gems]
     end

--- a/lib/bundleup/commands.rb
+++ b/lib/bundleup/commands.rb
@@ -29,7 +29,7 @@ module Bundleup
       expr = output.match?(/^Gem\s+Current\s+Latest/) ? OUTDATED_2_2_REGEXP : OUTDATED_2_1_REGEXP
 
       output.scan(expr).each_with_object({}) do |(name, newest, pin), gems|
-        gems[name] = { newest: newest, pin: pin }
+        gems[name] = { newest:, pin: }
       end
     end
 

--- a/lib/bundleup/logger.rb
+++ b/lib/bundleup/logger.rb
@@ -35,8 +35,8 @@ module Bundleup
       print "\r"
     end
 
-    def while_spinning(message, &block)
-      thread = Thread.new(&block)
+    def while_spinning(message, &)
+      thread = Thread.new(&)
       thread.report_on_exception = false
       message = message.ljust(console_width - 2)
       print "\r#{Colors.blue([spinner.next, message].join(' '))}" until wait_for_exit(thread, 0.1)

--- a/lib/bundleup/version_spec.rb
+++ b/lib/bundleup/version_spec.rb
@@ -7,7 +7,7 @@ module Bundleup
       _, operator, number = version.match(/^([^\d\s]*)\s*(.+)/).to_a
       operator = nil if operator.empty?
 
-      new(parts: number.split("."), operator: operator)
+      new(parts: number.split("."), operator:)
     end
 
     attr_reader :parts, :operator
@@ -25,7 +25,7 @@ module Bundleup
       return self if %w[!= > >=].include?(operator)
       return self.class.parse(">= 0") if %w[< <=].include?(operator)
 
-      self.class.new(parts: parts, operator: ">=")
+      self.class.new(parts:, operator: ">=")
     end
 
     def shift(new_version) # rubocop:disable Metrics/AbcSize
@@ -38,7 +38,7 @@ module Bundleup
     end
 
     def slice(amount)
-      self.class.new(parts: parts[0, amount], operator: operator)
+      self.class.new(parts: parts[0, amount], operator:)
     end
 
     def to_s

--- a/test/bundleup/cli_test.rb
+++ b/test/bundleup/cli_test.rb
@@ -114,12 +114,12 @@ class Bundleup::CLITest < Minitest::Test
 
   private
 
-  def with_clean_bundler_env(&block)
+  def with_clean_bundler_env(&)
     if defined?(Bundler)
       if Bundler.respond_to?(:with_unbundled_env)
-        Bundler.with_unbundled_env(&block)
+        Bundler.with_unbundled_env(&)
       else
-        Bundler.with_clean_env(&block)
+        Bundler.with_clean_env(&)
       end
     else
       yield

--- a/test/support/output_helpers.rb
+++ b/test/support/output_helpers.rb
@@ -6,7 +6,7 @@ module OutputHelpers
       original_logger = Bundleup.logger
       stdout = StringIO.new
       stdin = stdin.nil? ? $stdin : StringIO.new(stdin)
-      Bundleup.logger = Bundleup::Logger.new(stdout: stdout, stdin: stdin)
+      Bundleup.logger = Bundleup::Logger.new(stdout:, stdin:)
       yield
       stdout.string
     ensure


### PR DESCRIPTION
- Adopt Ruby 3.1+ implicit hash syntax
- Adopt Ruby 3.1+ anonymous block arg syntax
- Adopt Ruby 3.1+ `Array#intersect?`